### PR TITLE
Pass derivatives into compileGLesmos

### DIFF
--- a/src/plugins/GLesmos/exportAsGLesmos.ts
+++ b/src/plugins/GLesmos/exportAsGLesmos.ts
@@ -25,18 +25,31 @@ export function compileGLesmos(
   color: string,
   fillOpacity: number,
   lineOpacity: number,
-  lineWidth: number
+  lineWidth: number,
+  derivativeX: undefined | IRExpression,
+  derivativeY: undefined | IRExpression
 ): GLesmosShaderPackage {
   try {
     fillOpacity = clampParam(fillOpacity, 0, 1, 0.4);
     lineOpacity = clampParam(lineOpacity, 0, 1, 0.9);
     lineWidth = clampParam(lineWidth, 0, Infinity, 2.5);
 
-    const { source, deps } = emitChunkGL(concreteTree._chunk);
+    const functionDeps: string[] = [];
+
+    let source, derivativeXSource, derivativeYSource, deps;
+    ({ source, deps } = emitChunkGL(concreteTree._chunk));
+    deps.forEach((d) => accDeps(functionDeps, d));
     const type = getGLType(concreteTree.valueType);
 
-    const functionDeps: string[] = [];
-    deps.forEach((d) => accDeps(functionDeps, d));
+    if (lineWidth > 0 && derivativeX && derivativeY) {
+      ({ source: derivativeXSource, deps } = emitChunkGL(derivativeX._chunk));
+      deps.forEach((d) => accDeps(functionDeps, d));
+      ({ source: derivativeYSource, deps } = emitChunkGL(derivativeY._chunk));
+      deps.forEach((d) => accDeps(functionDeps, d));
+    }
+
+    console.log("derivativeX:", derivativeXSource);
+    console.log("derivativeY:", derivativeYSource);
 
     return {
       deps: functionDeps.map(getDefinition),

--- a/src/preload/moduleOverrides/glesmos.replacements
+++ b/src/preload/moduleOverrides/glesmos.replacements
@@ -208,9 +208,18 @@ else {
 *Replace* `else` with
 ```js
 else if ($this.userData.glesmos) {
+  const lines = $this.userData.lines !== false;
+  let derivativeX, derivativeY;
+  if (lines) {
+    try {
+      derivativeX = $ir.takeDerivative('x');
+      derivativeY = $ir.takeDerivative('y');
+    } catch(e) {}
+  }
   // newCompiled: GLesmosShaderPackage
   const newCompiled = self.dsm_compileGLesmos(
-    $ir, $styles.color, $styles.fillOpacity, $styles.lineOpacity, $this.userData.lines !== false ? $styles.lineWidth : 0.0, $styles.listIndex
+    $ir, $styles.color, $styles.fillOpacity, $styles.lineOpacity, lines ? $styles.lineWidth : 0.0,
+    derivativeX, derivativeY
   );
   const prev =  $graphs[$graphs.length - 1];
   if (prev?.graphMode === "GLesmos") {


### PR DESCRIPTION
This might help with #2. Currently just logs the derivatives;
hopefully you know how to use them. Btw as a warning, derivatives are
not always available (e.g. `sin(sin(sin(sin(...))))` blows up, and
Desmos gives up), so you will need to gracefully fallback to the finite
difference in this case.

Maybe the [symmetric difference quotient](https://en.wikipedia.org/wiki/Numerical_differentiation) could
help a little in that case, but it might be worth just treating it as rare
enough that the current finite difference is good enough.
