### PR TITLE
Support lines-only expressions in GLesmos

### DIFF
--- a/src/main/Controller.ts
+++ b/src/main/Controller.ts
@@ -534,8 +534,7 @@ export default class Controller {
       (model = Calc.controller.getItemModel(id)) &&
       model.type === "expression" &&
       model.formula &&
-      model.formula.expression_type === "IMPLICIT" &&
-      model.formula.is_inequality
+      model.formula.expression_type === "IMPLICIT"
     );
   }
 

--- a/src/plugins/GLesmos/exportAsGLesmos.ts
+++ b/src/plugins/GLesmos/exportAsGLesmos.ts
@@ -43,6 +43,7 @@ export function compileGLesmos(
       chunks: [
         {
           def: `${type} _f0(float x, float y) {\n    ${source}\n}`,
+          fill: fillOpacity > 0,
           color: `${colorVec4(color, fillOpacity)}`,
           line_color: `${colorVec4(color, lineOpacity)}`,
           line_width: lineWidth,

--- a/src/plugins/GLesmos/shaders.ts
+++ b/src/plugins/GLesmos/shaders.ts
@@ -12,6 +12,7 @@ export interface GLesmosShaderPackage {
 
 export interface GLesmosShaderChunk {
   def: string;
+  fill: boolean;
   color: string;
   line_color: string;
   line_width: number;
@@ -384,15 +385,18 @@ export function glesmosGetFinalPassShader(
     uniform sampler2D iChannel1;   // cache
     uniform vec2      iResolution; // canvas size
     uniform int       iDoOutlines;
+    uniform int       iDoFill;
 
     ${GLESMOS_SHARED}
 
     void main(){
 
       // fill
-      vec4 test = getPixel( texCoord, iChannel1 );
-      if( test.x > 0.0 ){
-        outColor = mixColor(outColor, ${chunk.color});
+      if ( iDoFill == 1 ) {
+        vec4 test = getPixel( texCoord, iChannel1 );
+        if( test.x > 0.0 ){
+          outColor = mixColor(outColor, ${chunk.color});
+        }
       }
 
       // lines
@@ -414,6 +418,7 @@ export function glesmosGetFinalPassShader(
   const shader = getShaderProgram(gl, id, VERTEX_SHADER, source);
   gl.useProgram(shader);
   setUniform(gl, shader, "iDoOutlines", "1i", chunk.line_width > 0 ? 1 : 0);
+  setUniform(gl, shader, "iDoFill", "1i", chunk.fill ? 1 : 0);
 
   return shader;
 }

--- a/src/preload/moduleOverrides/glesmos.replacements
+++ b/src/preload/moduleOverrides/glesmos.replacements
@@ -210,7 +210,7 @@ else {
 else if ($this.userData.glesmos) {
   // newCompiled: GLesmosShaderPackage
   const newCompiled = self.dsm_compileGLesmos(
-    $ir, $styles.color, $styles.fillOpacity, $styles.lineOpacity, $this.userData.lines !== false ? $styles.lineWidth : 0.0, $styles.listIndex
+    $ir, $styles.color, $styles.fillOpacity ?? 0, $styles.lineOpacity, $this.userData.lines !== false ? $styles.lineWidth : 0.0, $styles.listIndex
   );
   const prev =  $graphs[$graphs.length - 1];
   if (prev?.graphMode === "GLesmos") {

--- a/src/preload/moduleOverrides/glesmos.replacements
+++ b/src/preload/moduleOverrides/glesmos.replacements
@@ -2,7 +2,10 @@
 
 *plugin* `glesmos`
 
-## Add a menu option for switching an expression to glesmos rendering mode
+## Add a fill menu option for switching an expression to glesmos rendering mode
+
+Warning: this is duplicated below ("Add a lines menu option...") rather than
+adding an extra section to the menu view.
 
 *Module* `expressions/expression-menus/fill`
 
@@ -41,7 +44,6 @@ var $this = this;
 ```
 
 *Find* inside `template`
-
 ```js
 createElement($ToggleView.ToggleView
 ```
@@ -55,6 +57,62 @@ $DCGView.createElement(
   $DCGView.Components.If,
   {
     predicate: () => DesModder.controller.canBeGLesmos($this.id),
+  },
+  () => $DCGView.createElement(
+    "div",
+    { class: $DCGView.const("dcg-options-menu-section-title dsm-gl-fill-title") },
+    () => DesModder.controller.format("GLesmos-label-toggle-glesmos"),
+    $DCGView.createElement($ToggleView.ToggleView, {
+      ariaLabel: () => DesModder.controller.format("GLesmos-label-toggle-glesmos"),
+      toggled: () => window.DesModder?.controller?.isGlesmosMode?.($this.id),
+      onChange: (a) => window.DesModder?.controller?.toggleGlesmos?.($this.id),
+    })
+  )
+)
+```
+
+## Add a lines menu option for switching an expression to glesmos rendering mode
+
+Warning: this is duplicated above ("Add a fill menu option...").
+
+*Module* `expressions/expression-menus/lines`
+
+*Find* => `key`
+```js
+{ class: $DCGView.const('dcg-iconed-mathquill-row dcg-line-opacity-row') }
+```
+
+*Find_surrounding_template* `key` => `template`
+
+*Find* inside `template`
+```js
+createElement(
+  'div',
+  { class: $.const('dcg-options-menu-content') },
+  __rest__
+)
+```
+
+*Find* inside `template`
+```js
+var $this = this;
+```
+
+*Find* inside `template`
+```js
+createElement($ToggleView.ToggleView
+```
+
+Just add one more child.
+
+*Replace* `__rest__` with
+```js
+__rest__,
+$DCGView.createElement(
+  $DCGView.Components.If,
+  {
+    predicate: () => DesModder.controller.canBeGLesmos($this.id) &&
+      !Calc.controller.getItemModel($this.id)?.formula.is_inequality,
   },
   () => $DCGView.createElement(
     "div",


### PR DESCRIPTION
Resolves #3

- Show GLesmos option for implicit equalities
- Allow showing lines and not fill for GLesmos
- Show GLesmos option for implicit equalities (for real this time)
